### PR TITLE
Add more checks for other possible cases

### DIFF
--- a/src/Parsers/Helper/Utils.php
+++ b/src/Parsers/Helper/Utils.php
@@ -113,10 +113,16 @@ class Utils
                     &&
                     $node->value->name
                 ) {
-                    $value = method_exists($node->value->name,'getParts')
-                        ? implode('\\', $node->value->name->getParts())
-                        : $node->value->name->name;
-                    return $value === 'null' ? null : $value;
+                    if (method_exists($node->value->name, 'toString')) {
+                        $nameStr = $node->value->name->toString();
+                    } elseif ($node->value->name instanceof \PhpParser\Node\Name) {
+                        $nameStr = $node->value->name->__toString();
+                    } elseif ($node->value->name instanceof \PhpParser\Node\Identifier) {
+                        $nameStr = $node->value->name->name;
+                    } else {
+                        $nameStr = (string)$node->value->name;
+                    }
+                    return $nameStr === 'null' ? null : $nameStr;
                 }
             }
 


### PR DESCRIPTION

Following your suggestion, i dived deeper into the code and docs and found more use cases:

## 1. toString
 If it has a `toString()`, thats the easiest.

## 2. Name
if its a `Name`, `__toString()` has the full name as a string, which `getParts()` breaks apart.
```php
public function getParts(): array {
        return \explode('\\', $this->name);
}
```    
so we can avoid doing a `implode ( explode ( ... ) )`.

## 3. Identifier
just get the property. i dont think it will reach this check, because Identifier has [toString()](https://apiref.phpstan.org/1.11.x/source-vendor.nikic.php-parser.lib.PhpParser.Node.Identifier.html#41) anyway.
That was the only valid case where i could see `->name->name` .
> [!WARNING]  
> Let me know if i should delete this check.

## 4. everything else, cast to string the property that was already checked in L114.

# return
I kept the null check at the end.
