### PR TITLE
Handle depreaction warning

### DIFF
--- a/src/Parsers/PhpCodeParser.php
+++ b/src/Parsers/PhpCodeParser.php
@@ -465,7 +465,7 @@ class PhpCodeParser
                 unset($value); /* @phpstan-ignore-line ? */
             }
 
-            if (!isset($classes[$class->parentClass])) {
+            if (is_null($class->parentClass) || !isset($classes[$class->parentClass])) {
                 continue;
             }
 


### PR DESCRIPTION
"Deprecated: Using null as an array offset is deprecated, use an empty string instead on line 468"

Fixes #

#### Proposed Changes

*
*
*
*
